### PR TITLE
Add Markdown support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "fastapi==0.136.3",
     "itsdangerous==2.2.0",
     "jinja2==3.1.6",
+    "mistune==3.2.1",
     "orjson==3.11.8",  # This works with rustc 1.90 available on OpenBSD (orjson>=3.11.9 requires rustc 1.95)
     "pydantic==2.13.4",
     "strictyaml==1.7.3",

--- a/src/uproot/default/BaseMarkdown.html
+++ b/src/uproot/default/BaseMarkdown.html
@@ -1,0 +1,9 @@
+{% extends "Base.html" %}
+
+{% block title %}{% include_markdown '$Page.md:title' %}{% endblock title %}
+
+{% block main %}
+
+{% include_markdown '$Page.md' %}
+
+{% endblock main %}

--- a/src/uproot/pages.py
+++ b/src/uproot/pages.py
@@ -3,6 +3,7 @@
 
 import builtins
 import os
+import re
 import time
 import traceback
 import urllib.parse
@@ -11,8 +12,19 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
+import mistune
 import orjson
-from jinja2 import ChoiceLoader, Environment, FileSystemLoader, StrictUndefined
+from jinja2 import (
+    BaseLoader,
+    ChoiceLoader,
+    Environment,
+    FileSystemLoader,
+    StrictUndefined,
+    TemplateNotFound,
+    nodes,
+)
+from jinja2.ext import Extension
+from jinja2.parser import Parser
 from markupsafe import Markup
 from pydantic import validate_call
 from wtforms import Form as BaseForm
@@ -42,15 +54,86 @@ BUILTINS = {
     if callable(getattr(builtins, fname))
 }
 
+H1_PATTERN = re.compile(r"<h1>(.*?)</h1>\s*", re.DOTALL)
+
+
+class MarkdownLoader(BaseLoader):
+    def __init__(self, base_loader: BaseLoader) -> None:
+        self.base_loader = base_loader
+
+    def get_source(
+        self, environment: Environment, template: str
+    ) -> tuple[str, str | None, Callable[[], bool] | None]:
+        title_template = template.endswith(".md:title")
+        source_template = (
+            template.removesuffix(":title") if title_template else template
+        )
+        source, filename, uptodate = self.base_loader.get_source(
+            environment, source_template
+        )
+
+        if source_template.endswith(".md"):
+            html = cast(str, mistune.html(source))
+
+            h1s = H1_PATTERN.findall(html)
+            if title_template:
+                return (
+                    h1s[0].strip() if len(h1s) == 1 else "",
+                    filename,
+                    uptodate,
+                )
+
+            return (
+                H1_PATTERN.sub("", html, count=1) if len(h1s) == 1 else html,
+                filename,
+                uptodate,
+            )
+
+        return source, filename, uptodate
+
+
+class IncludeMarkdownExtension(Extension):
+    tags = {"include_markdown"}
+
+    def parse(self, parser: Parser) -> nodes.Node:
+        lineno = next(parser.stream).lineno
+        filename_node = parser.parse_expression()
+
+        if isinstance(filename_node, nodes.Const) and "$Page" in filename_node.value:
+            parts = filename_node.value.split("$Page")
+            concat_parts: list[nodes.Expr] = []
+            for i, part in enumerate(parts):
+                if i > 0:
+                    concat_parts.append(
+                        nodes.Getattr(nodes.Name("page", "load"), "__module__", "load")
+                    )
+                    concat_parts.append(nodes.Const("/"))
+                    concat_parts.append(
+                        nodes.Getattr(nodes.Name("page", "load"), "__name__", "load")
+                    )
+                if part:
+                    concat_parts.append(nodes.Const(part))
+
+            template_expr: nodes.Expr = nodes.Concat(concat_parts)
+        else:
+            template_expr = filename_node
+
+        return nodes.Include(template_expr, True, False).set_lineno(lineno)
+
+
 ENV = Environment(
-    loader=i18n.TranslateLoader(
-        ChoiceLoader(
-            [
-                FileSystemLoader(d.PATH),
-                FileSystemLoader(
-                    os.path.join(os.path.dirname(os.path.abspath(__file__)), "default")
-                ),
-            ]
+    loader=MarkdownLoader(
+        i18n.TranslateLoader(
+            ChoiceLoader(
+                [
+                    FileSystemLoader(d.PATH),
+                    FileSystemLoader(
+                        os.path.join(
+                            os.path.dirname(os.path.abspath(__file__)), "default"
+                        )
+                    ),
+                ]
+            )
         )
     ),
     autoescape=True,
@@ -59,6 +142,7 @@ ENV = Environment(
     auto_reload=True,
     enable_async=True,
     lstrip_blocks=True,
+    extensions=[IncludeMarkdownExtension],
 )
 
 
@@ -479,7 +563,19 @@ def truepath(page: type[Page]) -> str:
         return f"#{page.__name__}"
 
     if not hasattr(page, "template"):
-        return f"{page.__module__}/{page.__name__}.html"
+        html_path = f"{page.__module__}/{page.__name__}.html"
+
+        try:
+            ENV.get_template(html_path)
+        except TemplateNotFound:
+            md_path = f"{page.__module__}/{page.__name__}.md"
+            try:
+                ENV.get_template(md_path)
+                return "BaseMarkdown.html"
+            except TemplateNotFound:
+                pass
+
+        return html_path
 
     return page.template
 

--- a/tests/test_pages_markdown.py
+++ b/tests/test_pages_markdown.py
@@ -1,0 +1,159 @@
+from importlib.resources import files
+
+from jinja2 import ChoiceLoader, DictLoader, Environment, FileSystemLoader
+
+from uproot import i18n, pages
+from uproot.pages import IncludeMarkdownExtension, MarkdownLoader
+
+
+def make_environment(templates: dict[str, str]) -> Environment:
+    default_templates = files("uproot").joinpath("default")
+    return Environment(
+        loader=MarkdownLoader(
+            i18n.TranslateLoader(
+                ChoiceLoader(
+                    [
+                        DictLoader(templates),
+                        FileSystemLoader(str(default_templates)),
+                    ]
+                )
+            )
+        ),
+        autoescape=True,
+        enable_async=True,
+        extensions=[IncludeMarkdownExtension],
+    )
+
+
+def markdown_path(page: type) -> str:
+    return f"{page.__module__}/{page.__name__}.md"
+
+
+async def test_markdown_page_uses_h1_as_rendered_title():
+    class ExamplePage:
+        pass
+
+    environment = make_environment(
+        {
+            markdown_path(ExamplePage): (
+                "# Hello *{{ name }}*\n\n" "Value: **{{ value }}**\n"
+            ),
+            "Base.html": (
+                "{% set page_title %}{% block title %}{% endblock title %}"
+                "{% endset %}"
+                '{% if page_title %}<h1 id="uproot-title">'
+                "{{ page_title }}</h1>{% endif %}"
+                "<main>{% block main %}{% endblock main %}</main>"
+            ),
+        }
+    )
+
+    rendered = await environment.get_template("BaseMarkdown.html").render_async(
+        page=ExamplePage,
+        name="<Alice>",
+        value="<strong>",
+    )
+
+    assert '<h1 id="uproot-title">Hello <em>&lt;Alice&gt;</em></h1>' in rendered
+    assert "<h1>Hello" not in rendered
+    assert "<p>Value: <strong>&lt;strong&gt;</strong></p>" in rendered
+
+
+async def test_multiple_markdown_h1s_do_not_create_uproot_title():
+    class ExamplePage:
+        pass
+
+    environment = make_environment(
+        {
+            markdown_path(ExamplePage): "# First\n\n# Second\n",
+            "Base.html": (
+                "{% set page_title %}{% block title %}{% endblock title %}"
+                "{% endset %}"
+                '{% if page_title %}<h1 id="uproot-title">'
+                "{{ page_title }}</h1>{% endif %}"
+                "<main>{% block main %}{% endblock main %}</main>"
+            ),
+        }
+    )
+
+    rendered = await environment.get_template("BaseMarkdown.html").render_async(
+        page=ExamplePage
+    )
+
+    assert 'id="uproot-title"' not in rendered
+    assert "<h1>First</h1>" in rendered
+    assert "<h1>Second</h1>" in rendered
+
+
+def test_truepath_falls_back_to_markdown_but_prefers_html(monkeypatch):
+    class MarkdownPage:
+        pass
+
+    class HtmlPage:
+        pass
+
+    environment = make_environment(
+        {
+            markdown_path(MarkdownPage): "# Markdown\n",
+            markdown_path(HtmlPage): "# Markdown\n",
+            f"{HtmlPage.__module__}/{HtmlPage.__name__}.html": "HTML",
+        }
+    )
+    monkeypatch.setattr(pages, "ENV", environment)
+
+    assert pages.truepath(MarkdownPage) == "BaseMarkdown.html"
+    assert pages.truepath(HtmlPage) == f"{HtmlPage.__module__}/{HtmlPage.__name__}.html"
+
+
+def test_truepath_populates_template_cache(monkeypatch):
+    class HtmlPage:
+        pass
+
+    html_path = f"{HtmlPage.__module__}/{HtmlPage.__name__}.html"
+    environment = make_environment({html_path: "HTML"})
+    monkeypatch.setattr(pages, "ENV", environment)
+
+    assert pages.truepath(HtmlPage) == html_path
+    assert len(environment.cache) == 1
+    cached_template = environment.get_template(html_path)
+
+    assert cached_template is environment.get_template(html_path)
+
+
+async def test_markdown_translation_preserves_markdown(monkeypatch):
+    class ExamplePage:
+        pass
+
+    source_title = "Hello **world**"
+    source_body = "This is **important**"
+    environment = make_environment(
+        {
+            markdown_path(ExamplePage): (
+                f"# {{% translate %}}{source_title}{{% endtranslate %}}\n\n"
+                f"{{% translate %}}{source_body}{{% endtranslate %}}\n"
+            ),
+            "Base.html": (
+                "{% set page_title %}{% block title %}{% endblock title %}"
+                "{% endset %}"
+                "<h1>{{ page_title }}</h1>"
+                "<main>{% block main %}{% endblock main %}</main>"
+            ),
+        }
+    )
+    monkeypatch.setattr(i18n, "LANGUAGES", {"de"})
+    monkeypatch.setattr(
+        i18n,
+        "TERMS",
+        {
+            source_title: {"de": "Hallo **Welt**"},
+            source_body: {"de": "Dies ist **wichtig**"},
+        },
+    )
+
+    rendered = await environment.get_template("BaseMarkdown.html").render_async(
+        page=ExamplePage,
+        _uproot_internal={"language": "de"},
+    )
+
+    assert "<h1>Hallo <strong>Welt</strong></h1>" in rendered
+    assert "<p>Dies ist <strong>wichtig</strong></p>" in rendered

--- a/uv.lock
+++ b/uv.lock
@@ -658,6 +658,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mistune"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
+]
+
+[[package]]
 name = "msgpack"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1582,6 +1591,7 @@ dependencies = [
     { name = "httpx" },
     { name = "itsdangerous" },
     { name = "jinja2" },
+    { name = "mistune" },
     { name = "orjson" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -1630,6 +1640,7 @@ requires-dist = [
     { name = "isort", marker = "extra == 'dev'", specifier = "==8.0.1" },
     { name = "itsdangerous", specifier = "==2.2.0" },
     { name = "jinja2", specifier = "==3.1.6" },
+    { name = "mistune", specifier = "==3.2.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "orjson", specifier = "==3.11.8" },
     { name = "pip-tools", marker = "extra == 'dev'", specifier = "==7.5.3" },


### PR DESCRIPTION
Markdown pages render about 3.5% more slowly than standard HTML pages. These changes do not affect the performance of standard HTML pages.

[Example](https://github.com/mrpg/uproot-examples/tree/master/anchoring_markdown)